### PR TITLE
Add periodic hello broadcast for peer discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ python chat.py
 Abra um terminal para cada instância desejada e informe dados diferentes quando solicitado.
 Ao iniciar, o programa envia automaticamente uma mensagem de "hello" aos peers configurados
 com seu endereço de escuta. Assim, basta apontar para pelo menos um peer já existente e
-ele aprenderá seu endereço para as próximas replicações.
+ele aprenderá seu endereço para as próximas replicações. A partir desta versão,
+o servidor continua enviando periodicamente novas mensagens de "hello" a cada
+poucos segundos, permitindo que peers iniciados mais tarde também descubram o
+seu endereço.
 
 
 ## Trabalho:

--- a/chat.py
+++ b/chat.py
@@ -4,6 +4,7 @@ import time
 import sqlite3
 import logging
 import curses
+import threading
 from multiprocessing import Process
 
 HELLO_PREFIX = "__HELLO__ "
@@ -184,6 +185,13 @@ def servidor_receber(config):
     DB_PATH = config["db_path"]
 
     inicializar_banco()
+
+    def _hello_loop(interval=10):
+        while True:
+            enviar_hello_para_peers()
+            time.sleep(interval)
+
+    threading.Thread(target=_hello_loop, daemon=True).start()
 
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server_socket.bind((HOST_RECEBIMENTO, PORTA_RECEBIMENTO))


### PR DESCRIPTION
## Summary
- broadcast `hello` messages periodically from `servidor_receber`
- document background discovery behavior in README

## Testing
- `python -m py_compile chat.py`

------
https://chatgpt.com/codex/tasks/task_e_6843c6d4beec832ab4547e46f0808a52