### PR TITLE
Fix README trailing character

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,3 @@ Desenvolver uma solução computacional que explore os conceitos de paralelismo 
 ### Link para dicas de Markdown
 
 [Markdown Guide](https://www.markdownguide.org/cheat-sheet/)
-a


### PR DESCRIPTION
## Summary
- remove stray trailing `a` at the end of README

## Testing
- `python -m py_compile chat.py`

------
https://chatgpt.com/codex/tasks/task_e_6843c7ea24bc832a87a530ba911d0e00